### PR TITLE
Simplified the driver and the composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,7 @@
 
     "require": {
         "php":                           ">=5.3.1",
-        "behat/mink":                    "~1.4.3",
-        "behat/mink-browserkit-driver":  "1.0.*",
-        "symfony/browser-kit":           "~2.1",
-        "symfony/css-selector":          "~2.1",
-        "symfony/dom-crawler":           "~2.1",
-        "symfony/http-foundation":       "~2.1",
+        "behat/mink-browserkit-driver":  "~1.0,>=1.0.5",
         "symfony/http-kernel":           "~2.1",
         "symfony/process":               "~2.1"
     },

--- a/src/Behat/Mink/Driver/WUnitDriver.php
+++ b/src/Behat/Mink/Driver/WUnitDriver.php
@@ -31,24 +31,6 @@ class WUnitDriver extends BrowserKitDriver
     }
 
     /**
-     * Returns last response headers.
-     *
-     * @return array
-     */
-    public function getResponseHeaders()
-    {
-        return $this->getClient()->getResponse()->getHeaders();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getStatusCode()
-    {
-        return $this->getClient()->getResponse()->getStatus();
-    }
-
-    /**
      * Prepares URL for visiting.
      *
      * @param string $url


### PR DESCRIPTION
This is similar to https://github.com/Behat/MinkGoutteDriver/pull/19

This simplifies the drivers thanks to changes done in https://github.com/Behat/MinkBrowserKitDriver/pull/15

It also simplifies the composer requirement, allowing to have a single version compatible with both BrowserKitDriver 1.0.5+ (for Mink 1.4) and [BrowserKitDriver 1.1](https://github.com/Behat/MinkBrowserKitDriver/pull/16) (for Mink 1.5) by letting BrowserKitDriver define the Mink requirement.
the composer installation will fail because of the minimum stability right now as 1.0.5 is not tagged yet in the BrowserKitDriver so only the dev version could match the constraint right now.
I also removed a bunch of requirements which are actually coming from the dependencies.
